### PR TITLE
Adding Sample for Securing Token Endpoint

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <solution>
+        <add key="disableSourceControlIntegration" value="true" />
+    </solution>
+    <packageSources>
+        <clear/>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+</configuration>

--- a/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/AzureMapsWebApiToken.csproj
+++ b/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/AzureMapsWebApiToken.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Controllers/HomeController.cs
+++ b/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Controllers/HomeController.cs
@@ -5,11 +5,19 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using AzureMapsWebApiToken.Models;
+using Microsoft.AspNetCore.Http;
 
 namespace AzureMapsWebApiToken.Controllers
 {
     public class HomeController : Controller
     {
+        private readonly TokenAuthorizationProvider provider;
+
+        public HomeController(TokenAuthorizationProvider provider)
+        {
+            this.provider = provider;
+        }
+
         public IActionResult Index()
         {
             return View();
@@ -17,6 +25,10 @@ namespace AzureMapsWebApiToken.Controllers
 
         public IActionResult Maps()
         {
+            var option = new CookieOptions();
+            var token = provider.CreateToken();
+            option.Expires = token.ValidTo;         
+            Response.Cookies.Append("Authorization", token.RawData, option);
             return View();
         }
 

--- a/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Controllers/TokenController.cs
+++ b/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Controllers/TokenController.cs
@@ -16,6 +16,7 @@ namespace AzureMapsWebApiToken.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize("SessionToken")]
     public class TokenController : ControllerBase
     {
         /// <summary>
@@ -36,7 +37,6 @@ namespace AzureMapsWebApiToken.Controllers
             // tokenProvider will cache the token in memory, if you would like to reduce the dependency on Azure AD we recommend
             // implementing a distributed cache combined with using the other methods available on tokenProvider.
             string accessToken = await tokenProvider.GetAccessTokenAsync("https://atlas.microsoft.com/", cancellationToken: HttpContext.RequestAborted);
-            
             return Ok(accessToken);
         }
     }

--- a/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Models/TokenAuthorizationProvider.cs
+++ b/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Models/TokenAuthorizationProvider.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Cryptography;
+
+namespace AzureMapsWebApiToken.Models
+{
+    /// <summary>
+    /// This class is used to provide a basic JWT (Json Web Token) security token service which can issue short lived access tokens to be set on the Cookie responses to the website.
+    /// This access token is verfied to be issued from the website and that noone else forged a token. Then an Azure Maps token can be issued.
+    /// </summary>
+    public class TokenAuthorizationProvider
+    {
+        JwtSecurityTokenHandler jwtTokenHandler = new JwtSecurityTokenHandler();
+        public const string Audience = "AzureMapsToken";
+        public const string Issuer = "AnonymousAuthSample";
+        private static byte[] privateKey;
+
+        public JwtSecurityToken CreateToken()
+        {
+            var now = DateTime.UtcNow;
+            var signingCredentials = new SigningCredentials(CreateSecurityKey(), SecurityAlgorithms.HmacSha256Signature);
+            return jwtTokenHandler.CreateJwtSecurityToken(Issuer, Audience, new ClaimsIdentity(), now, now.AddMinutes(10), now, signingCredentials);
+        }
+
+        public static SecurityKey CreateSecurityKey()
+        {
+            return new SymmetricSecurityKey(CreatePrivateKey());
+        }
+
+        /// <summary>
+        /// In production code, you should consider storing the key in an Azure Key Vault. Secondly you must consider how to support private key rotation scenarios (support old key + new keys)
+        /// </summary>
+        private static byte[] CreatePrivateKey()
+        {
+            if (privateKey != null)
+            {
+                return privateKey;
+            }
+
+            using (RandomNumberGenerator rng = new RNGCryptoServiceProvider())
+            {
+                var tokenData = new byte[32];
+                rng.GetBytes(tokenData);
+                privateKey = tokenData;
+                return privateKey;
+            }
+        }
+    }
+}

--- a/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Startup.cs
+++ b/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Startup.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AzureMapsWebApiToken.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -31,8 +33,22 @@ namespace AzureMapsWebApiToken
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-
+            services.AddTransient<TokenAuthorizationProvider>();
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddAuthentication("Bearer").AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters()
+                {
+                    IssuerSigningKey = TokenAuthorizationProvider.CreateSecurityKey(),
+                    ValidIssuer = TokenAuthorizationProvider.Issuer,
+                    ValidAudience = TokenAuthorizationProvider.Audience
+                };
+            });
+            services.AddAuthorization(options =>
+            {
+                AuthorizationPolicyBuilder builder = new AuthorizationPolicyBuilder("Bearer");
+                options.AddPolicy("SessionToken", builder.RequireAuthenticatedUser().Build());
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Views/Home/Maps.cshtml
+++ b/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Views/Home/Maps.cshtml
@@ -27,6 +27,17 @@
         }
     }
 
+    function getCookie(name) {
+        var nameEQ = name + "=";
+        var ca = document.cookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+            if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+        }
+        return null;
+    }
+
     var map = new atlas.Map("map", {
         center: [-122.33, 47.64],
         zoom: 12,
@@ -40,6 +51,7 @@
                 resolveFunc = resolve;
                 rejectFunc = reject;
                 xhttp.open("GET", url, true);
+                xhttp.setRequestHeader("Authorization", 'Bearer ' + getCookie("Authorization"));
                 xhttp.onreadystatechange = tokenResolver;
                 xhttp.send();
             }


### PR DESCRIPTION
This sample provides a basic JWT token service which issues JWT tokens and set's the Cookie response headers so that the client Javascript can extract the Cookie and apply the access token to be used to retrieve an Azure maps access token.