### PR TITLE
Adding in jti claim

### DIFF
--- a/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Controllers/TokenController.cs
+++ b/src/ClientGrant/AzureMapsWebApiToken/AzureMapsWebApiToken/Controllers/TokenController.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;


### PR DESCRIPTION
Adding a JTI, jwt token id claim to the JWT payload. You can use this id to track the session of the anonymous user. Additional authorization policies can be created based on the JTI claim. An example could include throttling if the token as been redeemed twice.